### PR TITLE
Bug correction for 2 bytes characters with test case

### DIFF
--- a/Tests/monetdb_bug.js
+++ b/Tests/monetdb_bug.js
@@ -1,0 +1,34 @@
+var MDB = require('monetdb')();
+ 
+var options = {
+    host     : 'localhost', 
+    port     : 50000, 
+    dbname   : 'demo', 
+    user     : 'monetdb', 
+    password : 'monetdb'
+};
+ 
+var conn = new MDB(options);
+conn.connect();
+ 
+//conn.query('SELECT * FROM tables where name =\'test\'').then(function(result) {
+var string = 'éééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééé';
+string += string;
+string += string;
+string += string;
+string += string;
+string += string;
+
+
+conn.query('SELECT \'' + string +'\' FROM tables ').then(function(result) {	
+    //Request simulate a lot of 2 bytes characters. Some characters are truncated by the buffering in _handleData of mapi-connection.js
+	//Without correction some caracters became unknown
+	//Solved by using a StringDecoder
+	var res = JSON.stringify(result);
+	const regex = /é/gi;
+	console.log(res.replace(regex,''));
+	
+});
+
+
+conn.close();

--- a/src/mapi-connection.js
+++ b/src/mapi-connection.js
@@ -7,6 +7,8 @@
 var net = require('net');
 var crypto = require('crypto');
 var Q = require('q');
+const StringDecoder = require('string_decoder').StringDecoder;
+const decoder = new StringDecoder('utf8');
 
 var utils = require('./utils');
 
@@ -134,7 +136,13 @@ module.exports = function MapiConnection(options) {
         /* what is in the buffer is not necessary the entire block */
         var read_cnt = Math.min(data.length, _readLeftOver);
         try {
-            _readStr = _readStr + data.toString('utf8', 0, read_cnt);
+            //String concat involve problems with 2 bytes characters like é ou à 			
+            //_readStr = _readStr + data.toString('utf8', 0, read_cnt);
+			
+			var buf = new Buffer(read_cnt);
+			data.copy(buf, 0, 0, read_cnt);
+            _readStr = _readStr + decoder.write(buf);
+            
         } catch(e) {
             if(options.warning) {
                 options.warningFn(options.logger, 'Could not append read buffer to query result');


### PR DESCRIPTION
Hi,
This PR is to solve a bug for characters that use 2 bytes that can be truncated during the buffering of the monetdb response.
I have added a test case with the 'é' characters
Regards
Eric